### PR TITLE
Add mobile reader app and upstream sync workflow

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,19 @@
+name: Sync from upstream pinballprimer
+
+on:
+  schedule:
+    - cron: '0 14 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync fork with upstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync fork default branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh repo sync ${{ github.repository }} --source pinballprimer/pinballprimer.github.io

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# Pinball Primer (mobile)
+
+A mobile-friendly reader for [The Pinball Primer](https://pinballprimer.github.io/). All game content is from the original site — this is an unofficial reader that adds search, filters, and reflow-able typography. The original site is the authority.
+
+## How it works
+
+This repo is a fork of [pinballprimer/pinballprimer.github.io](https://github.com/pinballprimer/pinballprimer.github.io). The original `*.html` files at the repo root are untouched. The mobile reader lives in `/mobile/` and parses the upstream HTML in the browser at runtime — no build step, no scraping, no separate data file.
+
+```
+.
+├── *.html                      # upstream content (synced from pinballprimer)
+├── *.jpg                       # upstream images
+├── mobile/                     # the mobile reader (this repo's additions)
+│   ├── index.html              # search and filters
+│   ├── game.html               # reader view
+│   ├── styles.css              # mobile-first typography
+│   ├── parser.js               # DOMParser helpers for gamelist + game pages
+│   ├── app.js                  # index page logic
+│   └── game.js                 # game page logic
+└── .github/workflows/
+    └── sync-upstream.yml       # weekly fork sync from pinballprimer
+```
+
+## Run locally
+
+The reader uses relative URLs (`../gamelist.html`, `../{game_id}.html`) so it needs an HTTP server serving from the repo root.
+
+```bash
+cd ~/Documents/ai/pinballprimer-mobile
+python3 -m http.server 8080
+# open http://localhost:8080/mobile/
+```
+
+Any static server works. Don't open `mobile/index.html` directly via `file://` — `fetch()` won't read local files.
+
+## Deploy
+
+GitHub Pages, deployed from the repo root on `main`:
+
+1. **Settings → Pages**
+2. **Source:** Deploy from a branch
+3. **Branch:** `main` / `/(root)`
+4. Save
+
+URL: `https://branables.github.io/pinballprimer-mobile/mobile/`
+
+The original site is also served at the repo root: `https://branables.github.io/pinballprimer-mobile/` — kept intact so the mobile reader can fetch from it.
+
+## Stay in sync with upstream
+
+Two ways:
+
+**Automatic** — `.github/workflows/sync-upstream.yml` runs every Monday at 14:00 UTC and pulls upstream changes into `main`. You can also run it manually: **Actions → Sync from upstream pinballprimer → Run workflow**.
+
+**Manual** — on GitHub: your fork → "Sync fork" button → "Update branch". Or from the CLI:
+
+```bash
+gh repo sync branables/pinballprimer-mobile
+```
+
+To see what's changed upstream before syncing:
+
+```bash
+gh repo sync branables/pinballprimer-mobile --dry-run
+```
+
+Or visit https://github.com/branables/pinballprimer-mobile/compare/main...pinballprimer:pinballprimer.github.io:main
+
+## Architecture notes
+
+- **No build step.** `parser.js` does HTML → structured data in the browser. If you ever want full-text search across all game contents, you'd add a build step that pre-indexes; for now title/manufacturer/year/type are filterable from the gamelist page alone.
+- **Caching.** The parsed gamelist is cached in `sessionStorage` for 24h to avoid re-fetching on every page load.
+- **Navigation.** When you click a game from a filtered list, the filter state is preserved in the URL (`game.html?id=X&from=q%3Dking%26decade%3D1970s`). "Back" returns to that exact filter state. Prev/Next walks the filtered list (or falls back to alphabetical if you opened a game directly via a shared URL).
+
+## Future ideas
+
+- Tournament lists (multi-select games into a personal list stored in `localStorage`)
+- Full-text search across game contents (would require a small build step)
+- Offline support via service worker
+
+## Attribution
+
+All game content is from [The Pinball Primer](https://pinballprimer.github.io/) by its author. This project is a mobile reader on top of the public content of that site. Visit the original for the canonical version.

--- a/mobile/app.js
+++ b/mobile/app.js
@@ -1,0 +1,275 @@
+/* Index page: fetches gamelist, drives search and filters. */
+(function () {
+	'use strict';
+
+	const GAMELIST_URL = '../gamelist.html';
+	const CACHE_KEY = 'gamelist_cache_v1';
+	const CACHE_TTL_MS = 1000 * 60 * 60 * 24;
+	const NAVIGATION_LIST_KEY = 'currentFilteredIds';
+
+	const elements = {
+		search: document.getElementById('searchInput'),
+		decade: document.getElementById('decadeFilter'),
+		manufacturer: document.getElementById('manufacturerFilter'),
+		type: document.getElementById('typeFilter'),
+		gameList: document.getElementById('gameList'),
+		resultCount: document.getElementById('resultCount'),
+		clearFilters: document.getElementById('clearFilters'),
+	};
+
+	let allGames = [];
+
+	async function loadGames() {
+		const cached = readCache();
+		if (cached) {
+			return cached;
+		}
+		const response = await fetch(GAMELIST_URL);
+		if (!response.ok) {
+			throw new Error(`Failed to load gamelist (${response.status})`);
+		}
+		const htmlText = await response.text();
+		const games = window.Parser.parseGameList(htmlText);
+		writeCache(games);
+		return games;
+	}
+
+	function readCache() {
+		try {
+			const raw = sessionStorage.getItem(CACHE_KEY);
+			if (!raw) return null;
+			const parsed = JSON.parse(raw);
+			if (Date.now() - parsed.savedAt > CACHE_TTL_MS) return null;
+			return parsed.games;
+		} catch (err) {
+			return null;
+		}
+	}
+
+	function writeCache(games) {
+		try {
+			sessionStorage.setItem(CACHE_KEY, JSON.stringify({
+				savedAt: Date.now(),
+				games,
+			}));
+		} catch (err) {
+			/* sessionStorage may be unavailable or full; ignore */
+		}
+	}
+
+	function uniqueSortedValues(games, key) {
+		const set = new Set();
+		for (const game of games) {
+			if (game[key]) set.add(game[key]);
+		}
+		return Array.from(set).sort();
+	}
+
+	function uniqueSortedDecades(games) {
+		const set = new Set();
+		for (const game of games) {
+			if (game.decade) set.add(game.decade);
+		}
+		return Array.from(set).sort();
+	}
+
+	function populateSelect(selectEl, values) {
+		for (const value of values) {
+			const option = document.createElement('option');
+			option.value = value;
+			option.textContent = value;
+			selectEl.appendChild(option);
+		}
+	}
+
+	function readFiltersFromUrl() {
+		const params = new URLSearchParams(window.location.search);
+		return {
+			query: (params.get('q') || '').trim(),
+			decade: params.get('decade') || '',
+			manufacturer: params.get('manufacturer') || '',
+			type: params.get('type') || '',
+		};
+	}
+
+	function writeFiltersToUrl(filters) {
+		const params = new URLSearchParams();
+		if (filters.query) params.set('q', filters.query);
+		if (filters.decade) params.set('decade', filters.decade);
+		if (filters.manufacturer) params.set('manufacturer', filters.manufacturer);
+		if (filters.type) params.set('type', filters.type);
+		const newQs = params.toString();
+		const newUrl = newQs
+			? `${window.location.pathname}?${newQs}`
+			: window.location.pathname;
+		window.history.replaceState(null, '', newUrl);
+	}
+
+	function applyFiltersToInputs(filters) {
+		elements.search.value = filters.query;
+		elements.decade.value = filters.decade;
+		elements.manufacturer.value = filters.manufacturer;
+		elements.type.value = filters.type;
+	}
+
+	function readFiltersFromInputs() {
+		return {
+			query: elements.search.value.trim(),
+			decade: elements.decade.value,
+			manufacturer: elements.manufacturer.value,
+			type: elements.type.value,
+		};
+	}
+
+	function filterGames(games, filters) {
+		const queryLower = filters.query.toLowerCase();
+		return games.filter(game => {
+			if (filters.decade && game.decade !== filters.decade) return false;
+			if (filters.manufacturer && game.manufacturer !== filters.manufacturer) return false;
+			if (filters.type && game.type !== filters.type) return false;
+			if (queryLower && !game.title.toLowerCase().includes(queryLower)) return false;
+			return true;
+		});
+	}
+
+	function renderGames(games, filters) {
+		elements.gameList.innerHTML = '';
+		if (games.length === 0) {
+			const empty = document.createElement('p');
+			empty.className = 'empty-state';
+			empty.textContent = 'No games match your filters.';
+			elements.gameList.appendChild(empty);
+		} else {
+			const fragment = document.createDocumentFragment();
+			for (const game of games) {
+				fragment.appendChild(buildGameCard(game, filters));
+			}
+			elements.gameList.appendChild(fragment);
+		}
+
+		const total = allGames.length;
+		const shown = games.length;
+		elements.resultCount.textContent = shown === total
+			? `${shown} games`
+			: `${shown} of ${total} games`;
+
+		const hasFilters = Boolean(
+			filters.query || filters.decade || filters.manufacturer || filters.type
+		);
+		elements.clearFilters.hidden = !hasFilters;
+
+		saveFilteredIdsForNavigation(games);
+	}
+
+	function buildGameCard(game, filters) {
+		const card = document.createElement('a');
+		card.className = 'game-card';
+		card.href = buildGameLink(game, filters);
+
+		const title = document.createElement('div');
+		title.className = 'game-card-title';
+		title.textContent = game.title;
+
+		const meta = document.createElement('div');
+		meta.className = 'game-card-meta';
+		meta.textContent = buildMetaLine(game);
+
+		card.appendChild(title);
+		card.appendChild(meta);
+		return card;
+	}
+
+	function buildMetaLine(game) {
+		const pieces = [];
+		if (game.manufacturer) pieces.push(game.manufacturer);
+		if (game.type) pieces.push(game.type);
+		if (game.year) pieces.push(String(game.year));
+		return pieces.join(' · ');
+	}
+
+	function buildGameLink(game, filters) {
+		const params = new URLSearchParams();
+		params.set('id', game.id);
+		const fromQs = filtersToQueryString(filters);
+		if (fromQs) params.set('from', fromQs);
+		return `game.html?${params.toString()}`;
+	}
+
+	function filtersToQueryString(filters) {
+		const params = new URLSearchParams();
+		if (filters.query) params.set('q', filters.query);
+		if (filters.decade) params.set('decade', filters.decade);
+		if (filters.manufacturer) params.set('manufacturer', filters.manufacturer);
+		if (filters.type) params.set('type', filters.type);
+		return params.toString();
+	}
+
+	function saveFilteredIdsForNavigation(games) {
+		try {
+			const ids = games.map(g => g.id);
+			sessionStorage.setItem(NAVIGATION_LIST_KEY, JSON.stringify(ids));
+		} catch (err) {
+			/* ignore */
+		}
+	}
+
+	function debounce(fn, ms) {
+		let timer = null;
+		return function debounced(...args) {
+			clearTimeout(timer);
+			timer = setTimeout(() => fn.apply(this, args), ms);
+		};
+	}
+
+	function refresh() {
+		const filters = readFiltersFromInputs();
+		writeFiltersToUrl(filters);
+		const filtered = filterGames(allGames, filters);
+		renderGames(filtered, filters);
+	}
+
+	function clearFilters() {
+		elements.search.value = '';
+		elements.decade.value = '';
+		elements.manufacturer.value = '';
+		elements.type.value = '';
+		refresh();
+		elements.search.focus();
+	}
+
+	function showLoadError(error) {
+		elements.gameList.innerHTML = '';
+		const errBox = document.createElement('div');
+		errBox.className = 'error';
+		errBox.textContent = `Could not load game list: ${error.message}`;
+		elements.gameList.appendChild(errBox);
+		elements.resultCount.textContent = '';
+	}
+
+	async function init() {
+		try {
+			allGames = await loadGames();
+		} catch (err) {
+			showLoadError(err);
+			return;
+		}
+
+		populateSelect(elements.decade, uniqueSortedDecades(allGames));
+		populateSelect(elements.manufacturer, uniqueSortedValues(allGames, 'manufacturer'));
+		populateSelect(elements.type, uniqueSortedValues(allGames, 'type'));
+
+		const initialFilters = readFiltersFromUrl();
+		applyFiltersToInputs(initialFilters);
+
+		const filtered = filterGames(allGames, initialFilters);
+		renderGames(filtered, initialFilters);
+
+		elements.search.addEventListener('input', debounce(refresh, 120));
+		elements.decade.addEventListener('change', refresh);
+		elements.manufacturer.addEventListener('change', refresh);
+		elements.type.addEventListener('change', refresh);
+		elements.clearFilters.addEventListener('click', clearFilters);
+	}
+
+	init();
+})();

--- a/mobile/game.html
+++ b/mobile/game.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+	<meta name="theme-color" content="#1a1a1a" />
+	<title>Game — Pinball Primer (mobile)</title>
+	<link rel="stylesheet" href="styles.css" />
+</head>
+<body class="page-game">
+
+	<header class="game-topbar">
+		<a id="backLink" class="back-link" href="index.html">← Back</a>
+		<a id="sourceLink" class="source-link" href="#" target="_blank" rel="noopener">Source ↗</a>
+	</header>
+
+	<main class="container">
+		<article id="gameContent" class="game-content" aria-live="polite">
+			<p class="loading">Loading...</p>
+		</article>
+	</main>
+
+	<nav class="prev-next" aria-label="Adjacent games">
+		<a id="prevLink" class="prev-next-link" href="#" hidden>← Previous</a>
+		<a id="nextLink" class="prev-next-link prev-next-next" href="#" hidden>Next →</a>
+	</nav>
+
+	<footer class="site-footer">
+		<p>
+			Content from
+			<a href="https://pinballprimer.github.io/" target="_blank" rel="noopener">The Pinball Primer</a>.
+		</p>
+	</footer>
+
+	<script src="parser.js"></script>
+	<script src="game.js"></script>
+</body>
+</html>

--- a/mobile/game.js
+++ b/mobile/game.js
@@ -1,0 +1,176 @@
+/* Game reader page: fetches a single game's HTML and renders it cleanly. */
+(function () {
+	'use strict';
+
+	const NAVIGATION_LIST_KEY = 'currentFilteredIds';
+	const GAMELIST_URL = '../gamelist.html';
+
+	const elements = {
+		content: document.getElementById('gameContent'),
+		back: document.getElementById('backLink'),
+		source: document.getElementById('sourceLink'),
+		prev: document.getElementById('prevLink'),
+		next: document.getElementById('nextLink'),
+	};
+
+	function readPageParams() {
+		const params = new URLSearchParams(window.location.search);
+		return {
+			id: params.get('id') || '',
+			from: params.get('from') || '',
+		};
+	}
+
+	function configureBackLink(fromQueryString) {
+		elements.back.href = fromQueryString
+			? `index.html?${fromQueryString}`
+			: 'index.html';
+	}
+
+	function configureSourceLink(id) {
+		elements.source.href = `https://pinballprimer.github.io/${id}.html`;
+	}
+
+	function getNavigationIds(currentId) {
+		try {
+			const raw = sessionStorage.getItem(NAVIGATION_LIST_KEY);
+			if (!raw) return null;
+			const ids = JSON.parse(raw);
+			if (!Array.isArray(ids) || ids.length === 0) return null;
+			if (!ids.includes(currentId)) return null;
+			return ids;
+		} catch (err) {
+			return null;
+		}
+	}
+
+	async function fetchAlphabeticalIds() {
+		try {
+			const response = await fetch(GAMELIST_URL);
+			if (!response.ok) return null;
+			const html = await response.text();
+			const games = window.Parser.parseGameList(html);
+			return games.map(g => g.id);
+		} catch (err) {
+			return null;
+		}
+	}
+
+	function buildPrevNextHref(targetId, fromQueryString) {
+		const params = new URLSearchParams();
+		params.set('id', targetId);
+		if (fromQueryString) params.set('from', fromQueryString);
+		return `game.html?${params.toString()}`;
+	}
+
+	function configurePrevNext(ids, currentId, fromQueryString) {
+		const index = ids.indexOf(currentId);
+		if (index === -1) return;
+
+		if (index > 0) {
+			elements.prev.href = buildPrevNextHref(ids[index - 1], fromQueryString);
+			elements.prev.hidden = false;
+		}
+		if (index < ids.length - 1) {
+			elements.next.href = buildPrevNextHref(ids[index + 1], fromQueryString);
+			elements.next.hidden = false;
+		}
+	}
+
+	async function loadGameHtml(id) {
+		const response = await fetch(`../${id}.html`);
+		if (!response.ok) {
+			throw new Error(`Could not load game (${response.status})`);
+		}
+		return response.text();
+	}
+
+	function renderGame(parsed) {
+		elements.content.innerHTML = '';
+
+		const titleEl = document.createElement('h1');
+		titleEl.textContent = parsed.title;
+		elements.content.appendChild(titleEl);
+
+		const metaPieces = [];
+		if (parsed.manufacturer) metaPieces.push(parsed.manufacturer);
+		if (parsed.type) metaPieces.push(parsed.type);
+		if (parsed.year) metaPieces.push(String(parsed.year));
+		if (metaPieces.length > 0) {
+			const metaEl = document.createElement('p');
+			metaEl.className = 'game-meta';
+			metaEl.textContent = metaPieces.join(' · ');
+			elements.content.appendChild(metaEl);
+		}
+
+		for (const section of parsed.sections) {
+			if (section.heading) {
+				const headingEl = document.createElement(`h${section.level}`);
+				headingEl.textContent = section.heading;
+				elements.content.appendChild(headingEl);
+			}
+			if (section.contentHtml) {
+				const wrapper = document.createElement('div');
+				wrapper.innerHTML = section.contentHtml;
+				rewriteImageSources(wrapper);
+				while (wrapper.firstChild) {
+					elements.content.appendChild(wrapper.firstChild);
+				}
+			}
+		}
+
+		document.title = `${parsed.title} — Pinball Primer (mobile)`;
+	}
+
+	function rewriteImageSources(container) {
+		for (const img of container.querySelectorAll('img')) {
+			const src = img.getAttribute('src') || '';
+			if (!src) continue;
+			if (src.startsWith('http') || src.startsWith('/') || src.startsWith('..')) continue;
+			img.setAttribute('src', `../${src}`);
+			img.removeAttribute('width');
+			img.removeAttribute('height');
+			img.removeAttribute('class');
+			img.setAttribute('loading', 'lazy');
+		}
+	}
+
+	function showError(message) {
+		elements.content.innerHTML = '';
+		const errBox = document.createElement('div');
+		errBox.className = 'error';
+		errBox.textContent = message;
+		elements.content.appendChild(errBox);
+	}
+
+	async function init() {
+		const { id, from } = readPageParams();
+		configureBackLink(from);
+
+		if (!id) {
+			showError('No game specified. Go back to the list.');
+			return;
+		}
+
+		configureSourceLink(id);
+
+		try {
+			const html = await loadGameHtml(id);
+			const parsed = window.Parser.parseGamePage(html);
+			renderGame(parsed);
+		} catch (err) {
+			showError(`Could not load this game: ${err.message}`);
+			return;
+		}
+
+		let ids = getNavigationIds(id);
+		if (!ids) {
+			ids = await fetchAlphabeticalIds();
+		}
+		if (ids) {
+			configurePrevNext(ids, id, from);
+		}
+	}
+
+	init();
+})();

--- a/mobile/index.html
+++ b/mobile/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+	<meta name="theme-color" content="#1a1a1a" />
+	<title>Pinball Primer (mobile)</title>
+	<link rel="stylesheet" href="styles.css" />
+</head>
+<body class="page-list">
+
+	<header class="topbar">
+		<h1 class="topbar-title">Pinball Primer</h1>
+		<p class="topbar-subtitle">Mobile-friendly view of <a href="https://pinballprimer.github.io/" target="_blank" rel="noopener">pinballprimer.github.io</a></p>
+	</header>
+
+	<main class="container">
+
+		<section class="filters" aria-label="Search and filters">
+			<input
+				id="searchInput"
+				type="search"
+				class="search-input"
+				placeholder="Search by game name..."
+				autocomplete="off"
+				inputmode="search"
+			/>
+
+			<div class="filter-row">
+				<label class="filter-label">
+					<span>Decade</span>
+					<select id="decadeFilter" class="filter-select">
+						<option value="">Any decade</option>
+					</select>
+				</label>
+
+				<label class="filter-label">
+					<span>Manufacturer</span>
+					<select id="manufacturerFilter" class="filter-select">
+						<option value="">Any manufacturer</option>
+					</select>
+				</label>
+
+				<label class="filter-label">
+					<span>Type</span>
+					<select id="typeFilter" class="filter-select">
+						<option value="">Any type</option>
+					</select>
+				</label>
+			</div>
+
+			<div class="result-summary">
+				<span id="resultCount">Loading...</span>
+				<button id="clearFilters" type="button" class="link-button" hidden>Clear filters</button>
+			</div>
+		</section>
+
+		<section id="gameList" class="game-list" aria-live="polite"></section>
+
+	</main>
+
+	<footer class="site-footer">
+		<p>
+			All game content from
+			<a href="https://pinballprimer.github.io/" target="_blank" rel="noopener">The Pinball Primer</a>.
+			This is an unofficial mobile-friendly reader.
+		</p>
+	</footer>
+
+	<script src="parser.js"></script>
+	<script src="app.js"></script>
+</body>
+</html>

--- a/mobile/parser.js
+++ b/mobile/parser.js
@@ -1,0 +1,171 @@
+/* Parses upstream Pinball Primer HTML into structured data.
+   Exposed as window.Parser. */
+(function () {
+	'use strict';
+
+	const TITLE_METADATA_PATTERN = /^(.+?)\s*\(([^)]+)\)\s*$/;
+	const KNOWN_TYPES = new Set(['EM', 'SS', 'AN', 'DMD', 'LCD']);
+
+	function parseTitleMetadata(rawTitle) {
+		const match = rawTitle.match(TITLE_METADATA_PATTERN);
+		if (!match) {
+			return { title: rawTitle.trim(), manufacturer: '', type: '', year: null };
+		}
+		const title = match[1].trim();
+		const insideParens = match[2].split(',').map(s => s.trim());
+
+		let manufacturer = '';
+		let type = '';
+		let year = null;
+
+		for (const piece of insideParens) {
+			if (/^\d{4}$/.test(piece)) {
+				year = parseInt(piece, 10);
+			} else if (KNOWN_TYPES.has(piece)) {
+				type = piece;
+			} else {
+				manufacturer = manufacturer ? `${manufacturer}, ${piece}` : piece;
+			}
+		}
+
+		return { title, manufacturer, type, year };
+	}
+
+	function decadeForYear(year) {
+		if (!year) return null;
+		return `${Math.floor(year / 10) * 10}s`;
+	}
+
+	function parseGameList(htmlText) {
+		const doc = new DOMParser().parseFromString(htmlText, 'text/html');
+		const links = doc.querySelectorAll('a[href$=".html"]');
+		const games = [];
+
+		for (const link of links) {
+			const href = link.getAttribute('href') || '';
+			if (!href.endsWith('.html')) continue;
+			if (href.startsWith('http')) continue;
+			if (href.includes('#')) continue;
+			if (['gamelist.html', 'index.html', 'about.html', 'header.html', 'footer.html', '404.html'].includes(href)) continue;
+
+			const rawText = (link.textContent || '').trim();
+			if (!rawText) continue;
+
+			const meta = parseTitleMetadata(rawText);
+			const id = href.replace(/\.html$/, '');
+
+			games.push({
+				id,
+				url: href,
+				rawLabel: rawText,
+				title: meta.title,
+				manufacturer: meta.manufacturer,
+				type: meta.type,
+				year: meta.year,
+				decade: decadeForYear(meta.year),
+			});
+		}
+
+		return games;
+	}
+
+	function isContentEndComment(node) {
+		return node.nodeType === Node.COMMENT_NODE
+			&& (node.nodeValue || '').trim().toLowerCase().startsWith('end of content');
+	}
+
+	function isIframeNode(node) {
+		return node.nodeType === Node.ELEMENT_NODE && node.tagName === 'IFRAME';
+	}
+
+	function isHeading(node) {
+		return node.nodeType === Node.ELEMENT_NODE && /^H[123]$/.test(node.tagName);
+	}
+
+	function isContentBlock(node) {
+		if (node.nodeType !== Node.ELEMENT_NODE) return false;
+		return ['P', 'UL', 'OL', 'IMG', 'BLOCKQUOTE', 'PRE', 'TABLE', 'DIV', 'BR'].includes(node.tagName);
+	}
+
+	function extractImageInfo(element) {
+		const img = element.tagName === 'IMG' ? element : element.querySelector('img');
+		if (!img) return null;
+		return {
+			src: img.getAttribute('src') || '',
+			alt: img.getAttribute('alt') || '',
+		};
+	}
+
+	function parseGamePage(htmlText) {
+		const doc = new DOMParser().parseFromString(htmlText, 'text/html');
+		const body = doc.body;
+		if (!body) {
+			return { title: '', manufacturer: '', year: null, sections: [], image: null };
+		}
+
+		const h1 = body.querySelector('h1');
+		const rawTitle = h1 ? (h1.textContent || '').trim() : '';
+		const meta = parseTitleMetadata(rawTitle);
+
+		const sections = [];
+		let currentSection = null;
+		let image = null;
+
+		const finishSection = () => {
+			if (currentSection && currentSection.contentHtml.trim()) {
+				sections.push(currentSection);
+			} else if (currentSection) {
+				sections.push(currentSection);
+			}
+			currentSection = null;
+		};
+
+		for (const node of Array.from(body.childNodes)) {
+			if (isContentEndComment(node)) break;
+			if (isIframeNode(node)) continue;
+			if (node === h1) continue;
+
+			if (isHeading(node)) {
+				finishSection();
+				currentSection = {
+					level: parseInt(node.tagName.substring(1), 10),
+					heading: (node.textContent || '').trim(),
+					contentHtml: '',
+				};
+				continue;
+			}
+
+			if (isContentBlock(node)) {
+				const imgInfo = extractImageInfo(node);
+				if (imgInfo && !image) image = imgInfo;
+
+				if (currentSection) {
+					currentSection.contentHtml += node.outerHTML;
+				} else {
+					sections.unshift({
+						level: 2,
+						heading: '',
+						contentHtml: node.outerHTML,
+					});
+				}
+			}
+		}
+		finishSection();
+
+		return {
+			title: meta.title,
+			manufacturer: meta.manufacturer,
+			year: meta.year,
+			type: meta.type,
+			sections,
+			image,
+		};
+	}
+
+	window.Parser = {
+		parseGameList,
+		parseGamePage,
+		parseTitleMetadata,
+		decadeForYear,
+	};
+})();

--- a/mobile/styles.css
+++ b/mobile/styles.css
@@ -1,0 +1,296 @@
+/* ---- Tokens (light theme defaults) ---- */
+:root {
+	--color-bg: #fafaf7;
+	--color-surface: #ffffff;
+	--color-surface-alt: #f0eee8;
+	--color-border: #d8d4ca;
+	--color-text: #1a1a1a;
+	--color-text-muted: #5a5650;
+	--color-accent: #b8000d;
+	--color-accent-soft: #f4d3d6;
+	--color-link: #0050a8;
+
+	--radius: 10px;
+	--radius-sm: 6px;
+	--space-1: 4px;
+	--space-2: 8px;
+	--space-3: 12px;
+	--space-4: 16px;
+	--space-5: 24px;
+	--space-6: 32px;
+
+	--font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+	--font-size-body: 17px;
+	--font-size-small: 14px;
+	--font-size-h1: 28px;
+	--font-size-h2: 22px;
+	--font-size-h3: 19px;
+	--line-height-body: 1.55;
+}
+
+/* ---- Tokens (dark theme) ---- */
+@media (prefers-color-scheme: dark) {
+	:root {
+		--color-bg: #15151a;
+		--color-surface: #1f1f26;
+		--color-surface-alt: #292932;
+		--color-border: #3a3a44;
+		--color-text: #f0eee8;
+		--color-text-muted: #a8a59e;
+		--color-accent: #ff5868;
+		--color-accent-soft: #3a1a1f;
+		--color-link: #8ab4ff;
+	}
+}
+
+/* ---- Reset / base ---- */
+*, *::before, *::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
+body {
+	margin: 0;
+	font-family: var(--font-body);
+	font-size: var(--font-size-body);
+	line-height: var(--line-height-body);
+	color: var(--color-text);
+	background: var(--color-bg);
+	-webkit-font-smoothing: antialiased;
+	padding-bottom: env(safe-area-inset-bottom);
+}
+
+a { color: var(--color-link); }
+a:focus-visible { outline: 2px solid var(--color-link); outline-offset: 2px; border-radius: 3px; }
+
+h1, h2, h3 { line-height: 1.25; margin: 0 0 var(--space-3); }
+
+button { font: inherit; cursor: pointer; }
+
+/* ---- Layout ---- */
+.container {
+	max-width: 720px;
+	margin: 0 auto;
+	padding: var(--space-4);
+}
+
+/* ---- Index page top bar ---- */
+.topbar {
+	background: var(--color-accent);
+	color: #fff;
+	padding: var(--space-4);
+	padding-top: calc(var(--space-4) + env(safe-area-inset-top));
+}
+.topbar-title {
+	font-size: var(--font-size-h1);
+	margin: 0 0 var(--space-1);
+}
+.topbar-subtitle {
+	margin: 0;
+	font-size: var(--font-size-small);
+	opacity: 0.92;
+}
+.topbar-subtitle a { color: #fff; text-decoration: underline; }
+
+/* ---- Filters ---- */
+.filters {
+	margin-bottom: var(--space-5);
+}
+
+.search-input {
+	width: 100%;
+	padding: var(--space-3) var(--space-4);
+	font-size: var(--font-size-body);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius);
+	background: var(--color-surface);
+	color: var(--color-text);
+	margin-bottom: var(--space-3);
+}
+.search-input:focus { outline: 2px solid var(--color-link); outline-offset: 1px; }
+
+.filter-row {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+	gap: var(--space-2);
+	margin-bottom: var(--space-3);
+}
+
+.filter-label {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-1);
+	font-size: var(--font-size-small);
+	color: var(--color-text-muted);
+}
+
+.filter-select {
+	padding: var(--space-2) var(--space-3);
+	font-size: var(--font-size-body);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-sm);
+	background: var(--color-surface);
+	color: var(--color-text);
+	min-height: 40px;
+}
+
+.result-summary {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-size: var(--font-size-small);
+	color: var(--color-text-muted);
+}
+
+.link-button {
+	background: none;
+	border: none;
+	color: var(--color-link);
+	padding: var(--space-1) var(--space-2);
+	font-size: var(--font-size-small);
+}
+
+/* ---- Game list ---- */
+.game-list {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-2);
+}
+
+.game-card {
+	display: block;
+	padding: var(--space-3) var(--space-4);
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius);
+	text-decoration: none;
+	color: var(--color-text);
+}
+.game-card:active { background: var(--color-surface-alt); }
+.game-card-title {
+	font-weight: 600;
+	margin-bottom: var(--space-1);
+}
+.game-card-meta {
+	font-size: var(--font-size-small);
+	color: var(--color-text-muted);
+}
+
+.empty-state {
+	padding: var(--space-5);
+	text-align: center;
+	color: var(--color-text-muted);
+}
+
+/* ---- Game page ---- */
+.game-topbar {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding: var(--space-3) var(--space-4);
+	padding-top: calc(var(--space-3) + env(safe-area-inset-top));
+	background: var(--color-surface);
+	border-bottom: 1px solid var(--color-border);
+	position: sticky;
+	top: 0;
+	z-index: 10;
+}
+
+.back-link, .source-link {
+	text-decoration: none;
+	padding: var(--space-2) var(--space-3);
+	border-radius: var(--radius-sm);
+	font-size: var(--font-size-small);
+}
+.back-link { color: var(--color-link); font-weight: 500; }
+.source-link { color: var(--color-text-muted); }
+
+.game-content h1 {
+	font-size: var(--font-size-h1);
+	color: var(--color-accent);
+	margin-bottom: var(--space-4);
+}
+.game-content h2 {
+	font-size: var(--font-size-h2);
+	color: var(--color-text);
+	margin-top: var(--space-6);
+	padding-bottom: var(--space-2);
+	border-bottom: 2px solid var(--color-accent-soft);
+}
+.game-content h3 {
+	font-size: var(--font-size-h3);
+	color: var(--color-accent);
+	margin-top: var(--space-5);
+}
+.game-content p {
+	margin: 0 0 var(--space-4);
+}
+.game-content ul {
+	padding-left: var(--space-5);
+	margin: 0 0 var(--space-4);
+}
+.game-content li { margin-bottom: var(--space-2); }
+
+.game-content img {
+	display: block;
+	max-width: 100%;
+	height: auto;
+	margin: var(--space-4) auto;
+	border-radius: var(--radius-sm);
+	border: 1px solid var(--color-border);
+}
+
+.game-meta {
+	color: var(--color-text-muted);
+	font-size: var(--font-size-small);
+	margin-bottom: var(--space-5);
+}
+
+.loading {
+	color: var(--color-text-muted);
+	text-align: center;
+	padding: var(--space-6);
+}
+
+.error {
+	color: var(--color-accent);
+	padding: var(--space-4);
+	border: 1px solid var(--color-accent);
+	border-radius: var(--radius);
+	background: var(--color-accent-soft);
+}
+
+/* ---- Prev / next ---- */
+.prev-next {
+	display: flex;
+	justify-content: space-between;
+	padding: var(--space-4);
+	max-width: 720px;
+	margin: 0 auto;
+	gap: var(--space-2);
+}
+
+.prev-next-link {
+	display: inline-block;
+	padding: var(--space-3) var(--space-4);
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius);
+	text-decoration: none;
+	color: var(--color-text);
+	flex: 1;
+	text-align: center;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.prev-next-next { margin-left: auto; }
+
+/* ---- Footer ---- */
+.site-footer {
+	text-align: center;
+	padding: var(--space-5) var(--space-4);
+	color: var(--color-text-muted);
+	font-size: var(--font-size-small);
+}
+.site-footer p { margin: 0; }


### PR DESCRIPTION
Adds a mobile-friendly reader for the upstream Pinball Primer content, served as a static site from /mobile/. No build step: gamelist and game pages are fetched from the upstream HTML files at the repo root and parsed in the browser via DOMParser.

- mobile/: index (search + decade/manufacturer/type filters), game reader view with prev/next walking the filtered list, light/dark via prefers-color-scheme
- .github/workflows/sync-upstream.yml: weekly + manual fork sync from pinballprimer/pinballprimer.github.io
- README: setup, local dev, deploy, attribution