### PR TITLE
organize glossary with alphabetical sections

### DIFF
--- a/glossary.html
+++ b/glossary.html
@@ -20,6 +20,14 @@
 		h3 {
 			color:#ff88ff;
 		}
+        .floating {
+        	position: fixed;
+        	width: 120px;
+        	height: 60px;
+        	bottom: 10px;
+        	right: 40px;
+        	text-align: center;
+        }
 	</style>
 </head>
 
@@ -31,6 +39,15 @@
 
 <p>A glossary of pinball terms, objects, and slang, in alphabetical order.</p>
 
+<p>Quick Navigation:</p>
+<p><a href="#a">A</a> - <a href="#b">B</a> - <a href="#c">C</a> - <a href="#d">D</a> - <a href="#e">E</a> - <a
+		href="#f">F</a> - <a href="#g">G</a> - <a href="#h">H</a> - <a href="#i">I</a> - <a href="#j">J</a> - <a
+		href="#k">K</a> - <a href="#l">L</a> - <a href="#m">M</a> - <a href="#n">N</a> - <a href="#o">O</a> - <a
+		href="#p">P</a> - <a href="#q">Q</a> - <a href="#r">R</a> - <a href="#s">S</a> - <a href="#t">T</a> - <a
+		href="#u">U</a> - <a href="#v">V</a> - <a href="#w">W</a> - <a href="#x">X</a> - <a href="#y">Y</a> - <a
+		href="#z">Z</a></p>
+
+<h2 id="a">A</h2>
 <h3>Action button</h3>
 <p>A button, typically on the lockdown bar at the front of the game, that can be used for various purposes such as launching a ball into play, controlling a video mode, or spotting credit for a shot. An action button is present on most very modern tables, but appeared at least as far back as Black Rose (Bally Williams, 1992).</p>
 
@@ -60,6 +77,8 @@
 
 <h3>Autoplunge</h3>
 <p>The mechanism by which, or the action of, a ball being added to the playfield with no input from the player. Autoplungers first appeared on Data East games of the early 1990s and have become commonplace since then. A game may autoplunge a ball after a ball save is used, after a multiball lock has been made, at the start of a multiball feature, as part of the ball search function, or to force a player to begin playing (or risk losing their turn) if they are taking too much time to plunge the ball themselves.</p>
+
+<h2 id="b">B</h2>
 
 <h3>Backbox</h3>
 <p>The vertically positioned box at the back of a pinball game. Depending on the era and the game itself, backboxes may contain score reels, score displays, a computer, a dot-matrix display, a full LCD screen, speakers, physical features that show a player's progress toward a goal, or even minigames that they player can interact with at certain times. The contents of a backbox are hidden from the player's view by the backglass. Historically, backboxes are made partially or entirely of wood.</p>
@@ -112,6 +131,8 @@
 <h3>Buy-in</h3>
 <p>A way to extend a game by one additional ball at the price of an additional 1/2 credit or 1 credit for the purposes of working toward a high score. Buy-in balls typically have a longer ball save than standard balls and may light or start features on the table automatically. Machines may have separate high score tables for buy-in games versus standard games. </p>
 
+<h2 id="c">C</h2>
+
 <h3>Captive ball</h3>
 <p>A pinball trapped in a certain small area of a pinball table that can be hit with the ball in play, with the intention of getting the trapped ball to hit a target or rollover switch in its small area.</p>
 
@@ -145,6 +166,8 @@
 <h3>Credit dot</h3>
 <p>The use of a small dot on a game's display- such as "Credits: 1." instead of "Credits: 1", which subtly indicates to a game operator that a fault has been detected somewhere in the game, such as a mechanism being stuck or a switch not registering. First seen in High Speed (Williams, 1986). "False positive" credit dots can occur if a feature on a game is not triggered across many plays, which can cause the machine to assume said feature is faulty when it is not.</p>
 
+<h2 id="d">D</h2>
+
 <h3>Danesi lock</h3>
 <p>A method of locking balls for multiball by trapping them between two or more inline drop targets, named after Scott Danesi, who pioneered the design on Total Nuclear Annihilation (Spooky Pinball, 2017).</p>
 
@@ -172,6 +195,8 @@
 <h3>Drop target</h3>
 <p>A target, usually plastic and square or vertical rectangle in shape, that falls down to "disappear" under the table when hit with enough force. A shot that travels nearly parallel to the faces of a set of drop targets might be able to hit multiple targets at once: this is known as "sweeping" the targets. A set of multiple adjacent drop targets is frequently referred to as a bank, or even more specifically, an x-bank, where x is the number of targets themselves. Awards can be given for knocking down specific targets, all targets, or for completing the targets "in order" by hitting them one at a time in a certain direction. Occasionally, standup targets will be present behind a set of drop targets. See also: inline drop targets.</p>
 
+<h2 id="e">E</h2>
+
 <h3>Earplug modification</h3>
 <p>A modification to a pinball table that became popular in the early 2020s wherein an operator attaches an earplug to a certain part of a tilt bob to cause it to stop swinging faster. This is most commonly done to decrease the amount of time players tend to wait and let a swinging tilt bob settle before starting their turn in a tournament, or to help prevent tilt-throughs.</p>
 
@@ -180,6 +205,8 @@
 
 <h3>Extra ball</h3>
 <p>A major award given to a player, allowing them to take another turn after the current ball drains. Synonymous with the phrases "Shoot again" or "Same player shoots again". In most games released up until the early-1980s, players were limited to one extra ball per ball in play, meaning the current ball would need to drain and the extra ball would need to be used up before another could be earned. However, modern games or electromechanical "add-a-ball" games have the capability of storing or awarding multiple extra balls per ball in play, often to an operator-adjustable maximum. Under some game settings, the award called extra ball can be set to award points instead. In a competition or tournament setting, 4 things can be done with extra balls: they could be disabled outright, they could be set to a point value, they could be enabled with a rule in place that means you can plunge an extra ball and cannot use the flippers on them, or they could be left as-is (the latter typically only happens with certain single-player games).</p>
+
+<h2 id="f">F</h2>
 
 <h3>Fan layout</h3>
 <p>A type of pinball machine layout, usually in a modern (DMD or later) game, characterized by having only two flippers in the conventional locations at the bottom of the playfield; a selection of orbits, ramps, and lanes directly available from the flippers; and pop bumpers somewhat detached from the rest of the flow of the playfield, if they exist at all. Fan layouts are so named because the position of the shots or lights on the playfield commonly looks like a semicircle folding fan. The best-known fan layout games are Attack from Mars, Medieval Madness, and Monster Bash by Bally Williams in the late 1990s, but they are still somewhat common to see in the 21st century.</p>
@@ -193,11 +220,15 @@
 <h3>Free play</h3>
 <p>A pinball machine setting that allows games to be started for free, rather than requiring a coin to be inserted or a credit to have been previously earned.</p>
 
+<h2 id="g">G</h2>
+
 <h3>Gobble hole</h3>
 <p>A hole in the playfield of a pinball table that scores moderate to high points, but ends the current ball, acting as a drain that is somewhere other than the bottom of the game. Gobble holes were common in pinball games of the 1940s and 1950s, but quickly fell out of favor in the first half of the 1960s as pinball began to rebrand as a game of competition and skill rather than a form of gambling.</p>
 
 <h3>Grace period or Grace time</h3>
 <p>A brief period of lenience after a timed pinball feature ends where that feature or shot can still be used or collected. Most commonly seen relating to ball save, to account for the fact that a ball save timer may have run out when a ball was in an out lane and therefore was effectively dead without landing in the drain hole yet, or when relating to a timed mode or multiball.</p>
+
+<h2 id="h">H</h2>
 
 <h3>Habitrail</h3>
 <p>A pathway raised above the playfield for the ball to travel on, typically after the ball enters a vertical up-kicker or reaches the top of a ramp. To be sure not to impact playfield visibility too much, habitrails are usually made of clear plastic or bent metal wires.</p>
@@ -207,6 +238,8 @@
 
 <h3>Hurry-up</h3>
 <p>A brief timed mode that typically involves shooting one shot as quickly as possible. That shot will have a starting value, and the value will constantly decrease as the player takes longer to hit the shot, until the value reaches either 0 points or a predetermined minimum, at which point the opportunity disappears.</p>
+
+<h2 id="i">I</h2>
 
 <h3>IFPA</h3>
 <p>The International Flipper Pinball Association, the world's largest governing body for pinball tournaments and world rankings.</p>
@@ -232,14 +265,20 @@
 <h3>"It's more fun to compete"</h3>
 <p>A pinball slogan that first appeared in the late 1950s and 1960s, originally included to raise awareness to the fact that multiple people could play at the same time on a given machine, while also indicating that the machine was intended to play a game of skill, rather than solely being luck- or gambling-focused. In the modern era, "it's more fun to compete" is more frequently used as a phrase inviting and encouraging people to try playing in local pinball tournaments.</p>
 
+<h2 id="j">J</h2>
+
 <h3>Jackpot</h3>
 <p>Any major scoring award in a pinball game. Most of the time, jackpots are exclusive to multiball play, and require making a shot or series of shots while at least two balls are still in play. Jackpots can be awarded in single ball play as well, though, usually as an end goal for a series of tasks. Jackpots that have been multiplied for any reason are typically called double jackpots, triple jackpots, etc. The first game to refer to a specific award as a jackpot was likely High Speed (Williams, 1986).<br>See also: super jackpot, progressive jackpot.</p>
+
+<h2 id="k">K</h2>
 
 <h3>Kickback</h3>
 <p>A way to launch a ball back into play, usually from the left out lane. Almost always triggers automatically, but a few must be manually operated. Often a one-time use feature that must be reactivated.</p>
 
 <h3>Knocker</h3>
 <p>A noisemaker that makes a loud pop or knock sound, most frequently activated to celebrate the awarding of a free game, or sometimes an extra ball or large point award. In gambling-oriented pinball games of the mid-20th century, the knocker was a way to alert the game's operator that the current player needed to be paid out for replay(s) they earned.</p>
+
+<h2 id="l">L</h2>
 
 <h3>Lane change</h3>
 <p>The ability to use the flippers to change which scoring features are lit. Most commonly used to move the position of lights in parallel lanes at the top of the playfield to make it easier to light (or unlight, if the game demands it) the set of lanes. Introduced with Firepower (Williams, 1980). Early examples of lane change can only use the right flipper. Some games have a "multi-lane change" where each flipper changes a different set of lights/features. Beginning in the mid-1980s, both flippers could be used for lane change, but both would move the lights in question in the same direction. Not until the early 1990s did the current norm of forward + backward lane change become popular.</p>
@@ -271,6 +310,8 @@
 <h3>Lock stealing</h3>
 <p>The act of starting a multiball using balls locked by another player. Lock stealing is typically only seen on early solid state or alphanumeric games from about 1980-1990, or on a select handful of electromechanical games with multiball features from the late 1960s and early 1970s.</p>
 
+<h2 id="m">M</h2>
+
 <h3>Magna-save</h3>
 <p>A form of save only available on certain machines that can be manual or automatic and uses a magnet to slow the ball, stop the ball, or change its direction. Most magna-saves are positioned directly above the mouth of an in lane and can be activated by the player to prevent a ball moving toward the corresponding out lane. If a magna-save is manually activated, it will usually be done by a button on the side of the machine cabinet separate from the flipper button, or very rarely by an action button. Other types of magna-save are auto savers that trigger when the ball rolls over a certain point in the playfield, or magna-saves that put the ball on the tip of a flipper for a shot or cradle instead.</p>
 
@@ -295,11 +336,15 @@
 <h3>Mushroom bumper</h3>
 <p>A very small passive bumper seen only on some EM games.</p>
 
+<h2 id="n">N</h2>
+
 <h3>Nineing (9-ing) out a game</h3>
 <p>A gameplay style intended to earn a score as high as possible without rolling the score, such as trying to earn exactly 999,990 points on a game with a 6-digit display rather than hitting the 1,000,000 threshold. The premise dates back to the 1970s and 1980s, when score inflation meant that earning a score with more digits than the game could display was plausible, but the game's built-in high score leaderboards did not keep track of millions or ten-millions digits.</p>
 
 <h3>Nudge</h3>
 <p>A slight movement of a pinball table in a direction designed to influence the ball's movement. Contrary to the belief of many people new to pinball, nudging a game is not cheating! Pinball tables are designed to take a little bit of movement from players, and nudging a table is frequently intended to help make shots and complete goals. The game will tell you if you are being too rough with it by dishing out tilts or tilt warnings. The intention of a nudge is not to lift or change the angle of an entire machine to get the ball to go where you want it: nudging is supposed to briefly move an obstacle toward or away from the ball to change the direction of its bounce. Most nudges are done side to side or upward by pushing one side or the front of the machine. Nudging is just as much, if not more, of an exercise in timing and close attention then strength.</p>
+
+<h2 id="o">O</h2>
 
 <h3>One-way gate</h3>
 <p>A metal valve that a ball can only travel through in one direction, frequently positioned to force balls in particular directions at the top of a playfield or prevent a ball from re-entering the shooter lane. Some one-way gates can be electrically powered, allowing them to become two-directional if certain in-game criteria are met.</p>
@@ -315,6 +360,8 @@
 
 <h3>Out lane gate</h3>
 <p>A swiveling piece of wire that, as a reward, closes off an out lane to prevent a drain, instead funneling the ball back into an in lane (on either side) or the shooter lane (right side only). These gates are typically single use and will revert to their closed position once used.</p>
+
+<h2 id="p">P</h2>
 
 <h3>PAPA</h3>
 <p>The Professional and Amateur Pinball Association, a former governing body for pinball tournaments and world championships. PAPA is a branch of Replay Foundation, a nonprofit organization promoting the preservation and restoration of pinball games. PAPA went on indefinite hiatus in late 2020 due to the COVID-19 pandemic, but mostly returned in 2024. Major tournaments run by PAPA include the PAPA World Championships, a major international tournament series and/or charity event, and Pinburgh, an annual summer tournament in Pittsburgh, Pennsylvania, USA that was consistently one of the largest pinball tournaments in the world by player count pre-COVID-19.</p>
@@ -352,6 +399,8 @@
 <h3>Pro model</h3>
 <p>The least expensive model of most games produced by Stern Pinball since the early 2010s. Pro models of games usually contain slightly fewer features than their Premium and Limited Edition counterparts.</p>
 
+<h2 id="r">R</h2>
+
 <h3>Rage tilt</h3>
 <p>The act of tilting a pinball game violently or unnecessarily, usually following a drain or a loss in a tournament setting. Rage tilting is generally considered bad behavior and may award players a yellow or red card in a tournament.</p>
 
@@ -387,6 +436,8 @@
 
 <h3>Roto-target</h3>
 <p>A wheel of targets positioned vertically that partially poke out of the playfield such that only a few of the possible panels are visible at a time. The panels are often numbered or distinctly labelled, and the rewards for hitting a panel often depend on what the panel says and which position it was in. Games with a roto-target will also have a way to spin the roto-target, changing which faces are visible on the target mid-ball.</p>
+
+<h2 id="s">S</h2>
 
 <h3>Saucer/scoop</h3>
 <p>A small cupped area in a playfield that the ball can be shot into, then kicked out of in a particular direction. While the two terms refer to the same concept, most people will consider a scoop to be larger or deeper than a saucer, frequently causing the entire ball to temporarily drop below playfield level. Scoops were also frequently called sinkholes in the past, but this term is used less in the 21st century.</p>
@@ -473,6 +524,8 @@
 <h3>Swish</h3>
 <p>A ball that enters a rollover lane, usually a top lane or in lane, directly and cleanly rather than bouncing or rattling around, in the same spirit as a "nothing but net" shot in basketball.</p>
 
+<h2 id="t">T</h2>
+
 <h3>Tap out</h3>
 <p>If a player in a tournament setting has what the tournament director perceives to be an insurmountable lead, they may be tapped out- typically, physically tapped on the shoulder by said tournament director- which means they should stop playing immediately in exchange for an automatic first place in the round for the sake of keeping the tournament on schedule. If a player gets tapped out and another player after them does make up the seemingly-insurmountable lead, they will typically also receive the same first place award as the tapped out player.</p>
 
@@ -516,8 +569,12 @@
 <h3>Translite</h3>
 <p>A very thin coloured sheet of plastic applied to a piece of glass with clear trim, designed to be a substitute for (and more durable than) a backglass.</p>
 
+<h2 id="u">U</h2>
+
 <h3>Up-and-down action</h3>
 <p>A situation in which a bumper causes the ball to repeatedly trigger a lane of some sort, usually caused by the lane in question being perfectly vertical and sitting directly above the center of a pop bumper. Coupled with lane change, up-and-down action can make it possible to complete entire sets of lanes in just a single trip to that part of the playfield. So named because the ball goes up and down the lane repeatedly.</p>
+
+<h2 id="v">V</h2>
 
 <h3>Vary target</h3>
 <p>A spring-loaded target that can be pushed in various amounts and activate different switches, giving more or better rewards for shots that are strong and direct so that they push the target in more. Sometimes spelled vari-target.</p>
@@ -527,6 +584,8 @@
 
 <h3>"VUK" - Vertical up-kicker</h3>
 <p>A saucer that pops the ball upward away from the table surface, usually to put it on a habitrail or upper/alternate playfield.</p>
+
+<h2 id="w">W</h2>
 
 <h3>Walkoff</h3>
 <p>A walkoff occurs when the last player in a game (conventionally player 4) has enough score that they theoretically do not need to play their final turn. It is so named because that player can, in theory, plunge the ball and then walk away and still win the game. Some players may deny the walkoff and play their final ball anyway for practice, but this is considered a faux pas if the player in question already has a very large lead or if their continued play would delay the rest of the tournament.</p>
@@ -543,13 +602,19 @@
 <h3>WPPRs (pronounced "whoppers")</h3>
 <p>World Pinball Player Rankings, which are given to players based on the number of tournaments they play in, where they finish in those tournaments, and who they finish above in those tournaments. Players are ranked by the IFPA based on how many WPPRs they have earned. A variant is WWPPRs, commonly pronounced as "women's whoppers", which are a different flavor of WPPRs that exclusively involve women's tournaments.</p>
 
+<h2 id="y">Y</h2>
+
 <h3>Yellow card</h3>
 <p>A disciplinary action taken by a tournament director (TD) against a player for an IFPA/PAPA rules violation. Yellow cards are generally given for mid-level offenses such as rage tilting, illegal maneuvers such as bang backs or death saves, or repeated delay of game. TDs can decide whether or not to give a player a verbal warning before issuing a yellow card. Earning two yellow cards in a tournament is equivalent to a red card, which generally demands an automatic disqualification from the tournament in progress and possible additional disciplinary action. TDs can decide whether a player should receive a score of 0 alongside the yellow card in the round where the rules infraction occurred. Minor rules violations that lead to a score of 0 for the round, such as playing out of turn or tilting through another player's ball, do not typically warrant yellow cards unless they are done repeatedly or intentionally.</p>
+
+<h2 id="z">Z</h2>
 
 <h3>Zipper flippers</h3>
 <p>A pair of flippers that, as a reward, can be "zipped" together, meaning they are moved closer together and rotated slightly to form a barrier completely blocking the center drain. The flippers can still be used as normal while they are 'zipped', but due to how they are rotated, shotmaking with a zipped flipper is usually much different than with a conventional flipper. Zipper flippers are seen almost exclusively on Bally games designed by Ted Zale in the late 1960s and early 1970s, and were last seen from a major manufacturer on Medusa (Bally, 1981).</p>
 
 <!-- end of content -->
+
+<a class="floating" href="#top">Back to top</a>
 
 <iframe src="footer.html" width="100%" height="450" frameborder="0" scrolling="no"></iframe>
 

--- a/header.html
+++ b/header.html
@@ -4,9 +4,6 @@
 	<title></title>
 	<link href='https://fonts.googleapis.com/css2?family=Roboto' rel='stylesheet' type='text/css'>
 	<meta charset="UTF-8">
-	<link href="pagefind/pagefind-component-ui.css" rel="stylesheet">
-	<script src="pagefind/pagefind-component-ui.js" type="module"></script>
-
 	<link rel="stylesheet" href="pinballprimer.css">
 	<meta name="viewport" content="width=device-width, initial-scale=1"/>
 </head>


### PR DESCRIPTION
also cleans up an extra link inside the header that remained after moving the searchbox